### PR TITLE
updated header to compile under windows

### DIFF
--- a/header.h
+++ b/header.h
@@ -5,9 +5,16 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>
-#include <unistd.h>
 
+#if defined(_WIN32) || defined(_WIN64)
+#include <io.h>
+#define strcasecmp _stricmp
+#define strncasecmp _strnicmp
+#else
+#include <unistd.h>
 #define O_BINARY 0
+#endif
+
 #ifdef MAIN
 #define LINK
 #else
@@ -166,4 +173,3 @@ LINK byte   useExtended;
 
 
 #endif
-


### PR DESCRIPTION
Changed header.h to conditionally include the windows equivalents for unistd.h using the same conditional include logic as in the Basic-02 header file.
