### PR TITLE
Minor updates for Windows localtime function

### DIFF
--- a/asm.c
+++ b/asm.c
@@ -10,7 +10,7 @@
 #define MAIN
 
 #include <time.h>
-#include <sys/time.h>
+//moved sys/time.h to header.h
 
 #include "header.h"
 

--- a/header.h
+++ b/header.h
@@ -10,8 +10,10 @@
 #include <io.h>
 #define strcasecmp _stricmp
 #define strncasecmp _strnicmp
+#define localtime_r(X,Y) (localtime_s(Y,X))
 #else
 #include <unistd.h>
+#include <sys/time.h>
 #define O_BINARY 0
 #endif
 


### PR DESCRIPTION
Updated header.h file to define localtime_r() as localtime_s() for Windows.  Moved sys/time.h include statement to header file in the Linux (Else) section of the If Windows block.  After these changes, the code will compile successfully for both Linux and Windows.